### PR TITLE
Add markers css class

### DIFF
--- a/app/components/portableText/CodeBlockResolver/CodeBlockResolver.tsx
+++ b/app/components/portableText/CodeBlockResolver/CodeBlockResolver.tsx
@@ -1,12 +1,15 @@
 import 'prismjs/themes/prism.css';
 import { Refractor, registerLanguage } from "react-refractor";
+import css from "refractor/lang/css";
 import ts from "refractor/lang/typescript";
-import { CodeBlock } from "../../sanity/types";
+import { CodeBlock } from "../../../sanity/types";
+import './codeBlockResolver.css';
 
 type Props = {
   value: CodeBlock;
 }
 
+registerLanguage(css)
 registerLanguage(ts)
 
 export const CodeBlockResolver = ({ value }: Props) => {

--- a/app/components/portableText/CodeBlockResolver/codeBlockResolver.css
+++ b/app/components/portableText/CodeBlockResolver/codeBlockResolver.css
@@ -1,0 +1,7 @@
+.refractor-marker {
+  background-color: rgb(250, 217, 243);
+  margin-right: -1em;
+  margin-left: -1em;
+  padding-right: 1em;
+  padding-left: 0.75em;
+}

--- a/app/components/portableText/CodeBlockResolver/index.ts
+++ b/app/components/portableText/CodeBlockResolver/index.ts
@@ -1,0 +1,1 @@
+export { CodeBlockResolver } from "./CodeBlockResolver";


### PR DESCRIPTION
## Background

We want to be able to hightlight lines in the code block, but this is not supported out of the box and requires custom styling.

## Solution

Move the CodeBlockResolver to its own folder, and create a css file that holds the styling for the `refractor-marker` css class. This class is used to override the syntax highlighting. As this file is relevant to show code examples of, it also makes sense to register `css` as a language from refractor in the process.
