### PR TITLE
Create components for handing lists

### DIFF
--- a/app/components/css/ListItem/ListItem.tsx
+++ b/app/components/css/ListItem/ListItem.tsx
@@ -1,0 +1,13 @@
+import { Text } from '../Text'
+
+import './listItem.css'
+
+type Props = {
+  children: React.ReactNode
+}
+
+export const ListItem = ({ children }: Props) => (
+  <li className="list-item">
+    <Text fontSize="md">{children}</Text>
+  </li>
+)

--- a/app/components/css/ListItem/index.ts
+++ b/app/components/css/ListItem/index.ts
@@ -1,0 +1,1 @@
+export { ListItem } from './ListItem'

--- a/app/components/css/ListItem/listItem.css
+++ b/app/components/css/ListItem/listItem.css
@@ -1,0 +1,5 @@
+@import '../tokens/index.css';
+
+.list-item {
+  padding: var(--space-sm) 0;
+}

--- a/app/components/css/OrderedList/OrderedList.tsx
+++ b/app/components/css/OrderedList/OrderedList.tsx
@@ -1,0 +1,9 @@
+import './orderedList.css'
+
+type Props = {
+  children: React.ReactNode
+}
+
+export const OrderedList = ({ children }: Props) => (
+  <ol className="ordered-list">{children}</ol>
+)

--- a/app/components/css/OrderedList/index.ts
+++ b/app/components/css/OrderedList/index.ts
@@ -1,0 +1,1 @@
+export { OrderedList } from './OrderedList'

--- a/app/components/css/OrderedList/orderedList.css
+++ b/app/components/css/OrderedList/orderedList.css
@@ -1,0 +1,5 @@
+@import '../tokens/index.css';
+
+.ordered-list {
+  margin: 0;
+}

--- a/app/components/css/TextBlock/TextBlock.tsx
+++ b/app/components/css/TextBlock/TextBlock.tsx
@@ -8,6 +8,9 @@ import {
 import './textBlock.css'
 import { Heading } from '../Heading'
 import { Text } from '../Text'
+import { OrderedList } from '../OrderedList'
+import { ListItem } from '../ListItem'
+import { UnorderedList } from '../UnorderedList'
 
 type Props = {
   text: TextBlockType['text']
@@ -41,6 +44,11 @@ const components: Partial<PortableTextReactComponents> = {
     ),
     em: ({ children }) => <Text fontSize="md">{<em>{children}</em>}</Text>,
   },
+  list: {
+    bullet: ({ children }) => <UnorderedList>{children}</UnorderedList>,
+    number: ({ children }) => <OrderedList>{children}</OrderedList>,
+  },
+  listItem: ({ children }) => <ListItem>{children}</ListItem>,
 }
 
 export const TextBlock = ({ text }: Props) => {

--- a/app/components/css/UnorderedList/UnorderedList.tsx
+++ b/app/components/css/UnorderedList/UnorderedList.tsx
@@ -1,0 +1,9 @@
+import './unorderedList.css'
+
+type Props = {
+  children: React.ReactNode
+}
+
+export const UnorderedList = ({ children }: Props) => (
+  <ul className="unordered-list">{children}</ul>
+)

--- a/app/components/css/UnorderedList/index.ts
+++ b/app/components/css/UnorderedList/index.ts
@@ -1,0 +1,1 @@
+export { UnorderedList } from './UnorderedList'

--- a/app/components/css/UnorderedList/unorderedList.css
+++ b/app/components/css/UnorderedList/unorderedList.css
@@ -1,0 +1,5 @@
+@import '../tokens/index.css';
+
+.unordered-list {
+  margin: 0;
+}


### PR DESCRIPTION
## Background

The styling introduced did not have any custom components for lists! This resulted in PortableText parsing them as plain old `<ul>`, `<ol>` and `<li>` tags, which have no styling due to my no global styles policy.

## Solution

Created components for that specifically handles these three html tags. I added a bit more padding to make them match the same "airiness" as the rest of the content.
