### PR TITLE
Fix mobile presentation

### DIFF
--- a/app/root.css
+++ b/app/root.css
@@ -1,0 +1,3 @@
+body {
+  margin: 0;
+}

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -7,6 +7,8 @@ import {
   ScrollRestoration,
 } from '@remix-run/react'
 
+import './root.css'
+
 export const links: LinksFunction = () => [
   { rel: 'preconnect', href: 'https://fonts.googleapis.com' },
   {

--- a/app/routes/$/route.css
+++ b/app/routes/$/route.css
@@ -13,5 +13,5 @@
   flex-direction: column;
   gap: var(--space-xl);
   padding: var(--space-md);
-  width: 1024px;
+  max-width: 1024px;
 }


### PR DESCRIPTION
## Background

For some reason all the styling and elements looks horrible on mobile. Text overflows, the background only covers half and everything is just crazy.

## Solution

Fix a hardcoded width that should have been a maximum. Also, removed the default margin on the body due to creating a weird border due to different background colors.
