### PR TITLE
Create script for creating components with specific styling type

### DIFF
--- a/scripts/createComponent.ts
+++ b/scripts/createComponent.ts
@@ -1,0 +1,64 @@
+#!/usr/bin/env bun
+
+import { mkdir, writeFile, access } from 'fs/promises'
+import { constants } from 'fs'
+import { join } from 'path'
+import { toCamelCase, toPascalCase } from './utils'
+
+const supportedStyles = ['css'] as const
+
+async function componentExists(path: string): Promise<boolean> {
+  try {
+    await access(path, constants.F_OK) // Flag that the file is visible, but nothing about rwx permissions
+    return true
+  } catch {
+    return false
+  }
+}
+
+const args = process.argv.slice(2)
+const [name, styling] = args
+
+if (!name || !styling) {
+  console.error('❓ Missing arguments! Usage: createComponent <name> <styling>')
+  process.exit(1)
+}
+
+if (!supportedStyles.includes(styling as (typeof supportedStyles)[number])) {
+  console.error(
+    `🛑 Unsupported styling type. Supported types are: ${supportedStyles.join(', ')} 🎨`
+  )
+  process.exit(1)
+}
+
+async function createComponent(): Promise<void> {
+  const componentName = toPascalCase(name)
+  const stylingName = toCamelCase(name)
+  const componentDir = `app/components/${styling}/${componentName}`
+
+  if (await componentExists(componentDir)) {
+    console.error(`🛑 Component ${componentName} already exists. 🙅`)
+    process.exit(1)
+  }
+
+  await mkdir(componentDir, { recursive: true })
+
+  const files = {
+    [`${componentName}.tsx`]: `import './${stylingName}.${styling}'\nexport const ${componentName} = () => null\n`,
+    [`${stylingName}.${styling}`]: `/* Add your styles here */\n`,
+    ['index.ts']: `export { ${componentName} } from './${componentName}'\n`,
+  }
+
+  await Promise.all(
+    Object.entries(files).map(([fileName, content]) =>
+      writeFile(join(componentDir, fileName), content)
+    )
+  )
+
+  console.log(`✅ Component ${componentName} created successfully!`)
+}
+
+createComponent().catch((error) => {
+  console.error('❌ Error creating component:', error)
+  process.exit(1)
+})

--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -5,5 +5,5 @@ export function toPascalCase(str: string): string {
 }
 
 export function toCamelCase(str: string): string {
-  return str.replace(/-([a-z])/g, (_, char) => char.toUpperCase)
+  return str.replace(/-([a-z])/g, (_, char) => char.toUpperCase())
 }

--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -1,0 +1,9 @@
+export function toPascalCase(str: string): string {
+  return str.replace(/(^\w|-\w)/g, (match) =>
+    match.replace('-', '').toUpperCase()
+  )
+}
+
+export function toCamelCase(str: string): string {
+  return str.replace(/-([a-z])/g, (_, char) => char.toUpperCase)
+}


### PR DESCRIPTION
## Background

Creating new components can be kinda tedious, as there are manual efforts needed to setup basic boilerplate for tsx, styling and a barrel file.

## Solution

Create an awesome script for creating components, that creates the standard files needed for my basic components. To run you only need to run `./createComponent.ts <name> <styling>` in the `scripts` directory to do it. This should make it extendable to use other styling technices than just css that is the only supported one now, and is a part of the path to the correct component directory.

It also provides the basic code for both the barrel and exported component for const. I have chosen a bare-bones approach, so you'll have to add correct implementation instead of deleting unnecessary boilterplate.

It has some great user-friendy functionality too:
* Does not allow the creation of components that already exists
* Gives you explanation of usage if you provide missing arguments
* Renames the given component name to fit repo's code style
* Tells you what styling options are supported
* Gives a confirmation on successful creation, and gives error report on unsuccessful
