### PR TITLE
Use refactored CodeBlock type from Sanity

### DIFF
--- a/app/components/css/CodeBlock/CodeBlock.tsx
+++ b/app/components/css/CodeBlock/CodeBlock.tsx
@@ -34,7 +34,7 @@ export const CodeBlock = ({
         value={code}
       />
       {filename && (
-        <div className="code-block-filename">
+        <div className="code-block-filename" role="note" aria-label="filename">
           <Text fontSize="sm" variant="muted">
             {filename}
           </Text>

--- a/app/components/css/CodeBlock/CodeBlock.tsx
+++ b/app/components/css/CodeBlock/CodeBlock.tsx
@@ -3,6 +3,8 @@ import { Refractor, registerLanguage } from 'react-refractor'
 import css from 'refractor/lang/css'
 import ts from 'refractor/lang/typescript'
 
+import { Text } from '../Text'
+
 // The refractor-marker class is used to highlight specific lines in the code block
 // and is implicitly parsed by Refractor.
 import './codeBlock.css'
@@ -17,7 +19,12 @@ type Props = {
 registerLanguage(css)
 registerLanguage(ts)
 
-export const CodeBlock = ({ code, language, highlightedLines }: Props) => {
+export const CodeBlock = ({
+  code,
+  filename,
+  language,
+  highlightedLines,
+}: Props) => {
   return (
     <div className="code-block-container">
       <Refractor
@@ -26,6 +33,13 @@ export const CodeBlock = ({ code, language, highlightedLines }: Props) => {
         markers={highlightedLines}
         value={code}
       />
+      {filename && (
+        <div className="code-block-filename">
+          <Text fontSize="sm" variant="muted">
+            {filename}
+          </Text>
+        </div>
+      )}
     </div>
   )
 }

--- a/app/components/css/CodeBlock/codeBlock.css
+++ b/app/components/css/CodeBlock/codeBlock.css
@@ -4,6 +4,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  position: relative;
 }
 
 .code-block {
@@ -19,6 +20,12 @@
     max-width: 100%;
     overflow-x: auto;
   }
+}
+
+.code-block-filename {
+  position: absolute;
+  bottom: var(--space-md);
+  right: var(--space-sm);
 }
 
 .refractor-marker {

--- a/app/components/css/portableText/CodeBlockListResolver.tsx
+++ b/app/components/css/portableText/CodeBlockListResolver.tsx
@@ -9,13 +9,14 @@ export const CodeBlockListResolver = ({ value }: Props) => {
   return (
     <>
       {value.items?.map((item, index) => {
-        if (!item.code) return null
+        if (!item.code?.code) return null
         return (
           <CodeBlock
             key={index}
-            language={item.language}
-            code={item.code}
-            highlightedLines={item.highlightedLines}
+            filename={item.filename}
+            language={item.code.language}
+            code={item.code.code}
+            highlightedLines={item.code.highlightedLines}
           />
         )
       })}

--- a/app/sanity/sanity.types.ts
+++ b/app/sanity/sanity.types.ts
@@ -180,12 +180,18 @@ export type RichImageList = {
   >
 }
 
+export type CodeBlock = {
+  _type: 'codeBlock'
+  filename?: string
+  code?: Code
+}
+
 export type CodeBlockList = {
   _type: 'codeBlockList'
   items: Array<
     {
       _key: string
-    } & Code
+    } & CodeBlock
   >
 }
 
@@ -240,6 +246,7 @@ export type AllSanitySchemaTypes =
   | SanityAssetSourceData
   | SanityImageMetadata
   | RichImageList
+  | CodeBlock
   | CodeBlockList
   | Article
   | Slug


### PR DESCRIPTION
## Background

We want to be able to show metadata for code blocks, which have been implemented in Sanity to present a filename if specified.

## Solution

Ran TypeGen from Sanity again with the new type, and refactored the Resolver to use this instead. Now we show a filename in the bottom right corner of the code block if it has been defined.
